### PR TITLE
Convert project to Sass

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -130,7 +130,7 @@
   "schematics": {
     "@schematics/angular:component": {
       "prefix": "app",
-      "styleext": "css"
+      "styleext": "scss"
     },
     "@schematics/angular:directive": {
       "prefix": "app"


### PR DESCRIPTION
Sass (https://sass-lang.com/) lets us write cleaner, more concise stylesheets.